### PR TITLE
Added support for color, shuttle resizing, and edited shuttle shape

### DIFF
--- a/Logical/WidgetData/Main.st
+++ b/Logical/WidgetData/Main.st
@@ -11,6 +11,53 @@ PROGRAM _CYCLIC
 		animData.PosY[i]	:= LREAL_TO_REAL(gShuttleMon.Shuttle[i].Position.Y);
 		animData.RotZ[i]	:= LREAL_TO_REAL(gShuttleMon.Shuttle[i].Orientation.Angle1);
 		animData.Avail[i]	:= BOOL_TO_SINT(gShuttleMon.Shuttle[i].Available);
+		animData.ExtentBack[i]	:= LREAL_TO_REAL(gShuttleMon.Shuttle[i].ExtentToBack);
+		animData.ExtentFront[i]	:= LREAL_TO_REAL(gShuttleMon.Shuttle[i].ExtentToFront);
+		animData.Width[i]	:= LREAL_TO_REAL(gShuttleMon.Shuttle[i].Width);
+
+		
+		IF gShuttleMon.Shuttle[i].UserData <> 0 THEN
+			pUserData ACCESS gShuttleMon.Shuttle[i].UserData;
+				
+			CASE pUserData.Color OF
+				
+				ORANGE:
+					animData.ColorR[i]	:= 255;
+					animData.ColorG[i]	:= 127.5;
+					animData.ColorB[i]	:= 0.0;
+						
+				GREEN:
+					animData.ColorR[i]	:= 0.0;
+					animData.ColorG[i]	:= 255;
+					animData.ColorB[i]	:= 0.0;
+						
+				RED:
+					animData.ColorR[i]	:= 255;
+					animData.ColorG[i]	:= 0.0;
+					animData.ColorB[i]	:= 0.0;
+						
+				BLUE:
+					animData.ColorR[i]	:= 80;
+					animData.ColorG[i]	:= 80;
+					animData.ColorB[i]	:= 255;
+						
+				WHITE:
+					animData.ColorR[i]	:= 255;
+					animData.ColorG[i]	:= 255;
+					animData.ColorB[i]	:= 255;
+						
+				YELLOW:
+					animData.ColorR[i]	:= 204;
+					animData.ColorG[i]	:= 204;
+					animData.ColorB[i]	:= 0.0;
+
+				ELSE
+					animData.ColorR[i]	:= 127.5;
+					animData.ColorG[i]	:= 127.5;
+					animData.ColorB[i]	:= 127.5;
+			END_CASE
+		END_IF
+		
 	END_FOR;	
 	
 	

--- a/Logical/WidgetData/Types.typ
+++ b/Logical/WidgetData/Types.typ
@@ -4,6 +4,12 @@ TYPE
 		PosX : ARRAY[0..149]OF REAL;
 		RotZ : ARRAY[0..149]OF REAL;
 		PosY : ARRAY[0..149]OF REAL;
+		Width : ARRAY[0..149]OF REAL;
+		ExtentBack : ARRAY[0..149]OF REAL;
+		ExtentFront : ARRAY[0..149]OF REAL;
+		ColorR : ARRAY[0..149]OF REAL;
+		ColorG : ARRAY[0..149]OF REAL;
+		ColorB : ARRAY[0..149]OF REAL;
 		Avail : ARRAY[0..149]OF SINT;
 	END_STRUCT;
 END_TYPE

--- a/Logical/WidgetData/Variables.var
+++ b/Logical/WidgetData/Variables.var
@@ -1,4 +1,5 @@
 VAR
 	animData : animData_typ;
 	i : USINT;
+	pUserData : REFERENCE TO typShuttleUserData;
 END_VAR

--- a/Logical/mappView/Resources/Media/AnimWidget.html
+++ b/Logical/mappView/Resources/Media/AnimWidget.html
@@ -304,6 +304,12 @@
 				PosX: [0.0],
 				PosY: [0.0],
 				RotZ: [0.0],
+				ExtentBack: [0.0],
+				ExtentFront: [0.0],
+				Width: [0.0],
+				ColorR: [0.0],
+				ColorG: [0.0],
+				ColorB: [0.0]
 			}
 
 			for (var i = 0; i < 150; i++) {
@@ -319,6 +325,7 @@
 				ghost.setAttributeNS(null,'width','0.050');
 				ghost.setAttributeNS(null,'height','0.025');
 				ghost.setAttributeNS(null,'visibility','hidden');
+				ghost.setAttributeNS(null,'clip-path','polygon(0% 0%, 75% 0%, 100% 50%, 75% 100%, 0% 100%)');
 				ghost.setAttributeNS(null,'id','shuttle_' + String(i));
 				shell.appendChild(ghost); // this is major, i'm onsite
 			}
@@ -384,14 +391,100 @@
 				},
 				function() {});
 
+			parent.brease.services.opcua.read([{
+				"nodeId": "::WidgetData:animData.ExtentBack",
+				"attributeId": 13
+			}]).done(
+				function(value) {
+
+					for (var i = 0; i < 150; i++) {
+						animData.ExtentBack[i] = value.results["0"].value[i];
+					}
+
+				},
+				function() {});
+
+			parent.brease.services.opcua.read([{
+				"nodeId": "::WidgetData:animData.ExtentFront",
+				"attributeId": 13
+			}]).done(
+				function(value) {
+
+					for (var i = 0; i < 150; i++) {
+						animData.ExtentFront[i] = value.results["0"].value[i];
+					}
+
+				},
+				function() {});
+
+			parent.brease.services.opcua.read([{
+				"nodeId": "::WidgetData:animData.Width",
+				"attributeId": 13
+			}]).done(
+				function(value) {
+
+					for (var i = 0; i < 150; i++) {
+						animData.Width[i] = value.results["0"].value[i];
+					}
+
+				},
+				function() {});
+
+			parent.brease.services.opcua.read([{
+				"nodeId": "::WidgetData:animData.ColorR",
+				"attributeId": 13
+			}]).done(
+				function(value) {
+
+					for (var i = 0; i < 150; i++) {
+						animData.ColorR[i] = value.results["0"].value[i];
+					}
+
+				},
+				function() {});
+
+			parent.brease.services.opcua.read([{
+				"nodeId": "::WidgetData:animData.ColorG",
+				"attributeId": 13
+			}]).done(
+				function(value) {
+
+					for (var i = 0; i < 150; i++) {
+						animData.ColorG[i] = value.results["0"].value[i];
+					}
+
+				},
+				function() {});
+
+			parent.brease.services.opcua.read([{
+				"nodeId": "::WidgetData:animData.ColorB",
+				"attributeId": 13
+			}]).done(
+				function(value) {
+
+					for (var i = 0; i < 150; i++) {
+						animData.ColorB[i] = value.results["0"].value[i];
+					}
+
+				},
+				function() {});
+
+
+
+
 			// okay, now animate keyframes
 			for (var i = 0; i < 150; i++) {
 				var shuttle = document.getElementById('shuttle_' + String(i));
 				var container = document.getElementById('container_' + String(i));
+				var color = 'rgb(' + String(animData.ColorR[i]) + ',' + String(animData.ColorG[i]) + ',' + String(animData.ColorB[i]) + ')';
+				var height = animData.Width[i]/1000.0;
+				var width = (animData.ExtentFront[i]/1000.0) + (animData.ExtentBack[i]/1000.0)
+				var scaleY = height / shuttle.getAttribute('height');
+				var scaleX = width / shuttle.getAttribute('width');
 
 				// separate transform functions so the transition/inbetweening settings can be applied individually in CSS. this solves the wrist-flip issue
-				shuttle.setAttributeNS(null,'transform','rotate('+String(360.0-animData.RotZ[i])+')');
 				container.setAttributeNS(null,'transform','translate('+String(animData.PosX[i]/1000.0)+' '+String(animData.PosY[i]/-1000.0)+')');
+				shuttle.setAttributeNS(null,'transform','rotate('+String(360.0-animData.RotZ[i])+')'+' '+'scale('+String(scaleX)+' '+String(scaleY)+')');
 
 				// swap transition times based on rotation angle
 				if (animData.RotZ[i]%180 > 175 || animData.RotZ[i]%180 < 5){
@@ -402,6 +495,7 @@
 
 				if (animData.Avail[i] == 1) {
 					shuttle.setAttributeNS(null,'visibility','visible');
+					shuttle.setAttributeNS(null,'fill',color);
 				} else {
 					shuttle.setAttributeNS(null,'visibility','hidden');
 				}
@@ -444,9 +538,9 @@
 		}
 
 		rect {
-			stroke-width: 0.005;
-			fill: rgb(60,60,65);
-			stroke: rgb(187, 255, 0);
+			/* stroke-width: 0.005; */
+			/* fill: rgb(60,60,65); */
+			/* stroke: rgb(187, 255, 0); */
 		}
 		polyline {
 			stroke: rgb(110,110,115) !important;

--- a/Physical/Simulation/PC/Connectivity/OpcUA/OpcUaMap.uad
+++ b/Physical/Simulation/PC/Connectivity/OpcUA/OpcUaMap.uad
@@ -22,6 +22,12 @@
           <Variable Name="RotZ" />
           <Variable Name="PosY" />
           <Variable Name="Avail" />
+          <Variable Name="Width" />
+          <Variable Name="ExtentBack" />
+          <Variable Name="ExtentFront" />
+          <Variable Name="ColorR" />
+          <Variable Name="ColorG" />
+          <Variable Name="ColorB" />
         </Variable>
       </Task>
     </Module>


### PR DESCRIPTION
Should be tested for performance. My laptop runs well with a few shuttles, but a lot more and the animation really bogs down cpu usage. Maybe the interval at which the update function runs could be tweaked for better performance? Or, maybe we can read in the number of shuttles in the init and use that as the limit for all of the for loops.